### PR TITLE
Fixed dkim record not showing

### DIFF
--- a/pkg/scanner/requests.go
+++ b/pkg/scanner/requests.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/pkg/errors"
+	"net"
 )
 
 func (s *Scanner) getDNSAnswers(domain string, recordType uint16) ([]dns.RR, error) {
@@ -41,7 +42,7 @@ func (s *Scanner) GetDNSRecords(scanResult *ScanResult, recordTypes ...string) (
 		case "SPF":
 			scanResult.SPF, err = s.getTypeSPF(scanResult.Domain)
 		case "TXT":
-			scanResult.TXT, err = s.getTypeTXT(scanResult.Domain)
+			scanResult.TXT, err = net.LookupTXT(scanResult.Domain)
 		default:
 			return errors.New("invalid dns record type")
 		}
@@ -89,7 +90,7 @@ func (s *Scanner) getTypeBIMI(domain string) (string, error) {
 		"default._bimi." + domain,
 		domain,
 	} {
-		txtRecords, err := s.getTypeTXT(dname)
+		txtRecords, err := net.LookupTXT(dname)
 		if err != nil {
 			return "", nil
 		}
@@ -137,10 +138,7 @@ func (s *Scanner) getTypeDKIM(name string) (string, error) {
 		"mxvault._domainkey." + name,       // MxVault
 		name,
 	} {
-		txtRecords, err := s.getTypeTXT(dname)
-		if err != nil {
-			return "", nil
-		}
+		txtRecords, _ := net.LookupTXT(dname)
 
 		for _, txt := range txtRecords {
 			if strings.HasPrefix(txt, DKIMPrefix) {
@@ -157,7 +155,7 @@ func (s *Scanner) getTypeDMARC(domain string) (string, error) {
 		"_dmarc." + domain,
 		domain,
 	} {
-		txtRecords, err := s.getTypeTXT(dname)
+		txtRecords, err := net.LookupTXT(dname)
 		if err != nil {
 			return "", nil
 		}
@@ -188,7 +186,7 @@ func (s *Scanner) getTypeMX(domain string) (records []string, err error) {
 }
 
 func (s *Scanner) getTypeSPF(domain string) (string, error) {
-	txtRecords, err := s.getTypeTXT(domain)
+	txtRecords, err := net.LookupTXT(domain)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The dkim record was not showing in the output. I have fixed it. It was an issue with the function that gets the TXT records. I replaced it net.LookupTXT along with some other changes.

Context:
I am a Python developer. I had never used go before. Only had used pre-compiled binaries like amass, nuclei etc. I was searching for a tool that would get email related DNS settings and found this amazing tool. But it was not working properly with dkim. I re-created the tool in python for my use. Just for fun I wanted to see if I could fix it. After adding some fmt.Print statements (Never knew you had to import a library for a simple print function :P), I found out that the function that was responsible for fetching TXT records was not working properly when it came to dkim. I read on the internet about the function net.LookupTXT.  I replaced the previous function with this one and the program started working. I also had to make some changes in line 140-150. But now it is working. I have no idea about go best practices and guidelines so please excuse those. This is an amazing tool and I wanted to contribute whatever I can.

Regards,
Hanzala Ibn Zahid

